### PR TITLE
test: black-clean test_e2e (fix main CI)

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -56,6 +56,6 @@ def test_end_to_end_search(tmp_path):
     assert len(res) >= 1
     # gibbs.1of1 was built from the A0201 motif + small noise -> A0201 should win.
     top = res.sort_values("correlation", ascending=False).iloc[0]
-    assert top["hla"] == "HLA-A0201"  # canonical display = raw allotype, matches logo title
+    assert top["hla"] == "HLA-A0201"  # canonical display = raw allotype
     assert top["formatted"] == "A0201"  # raw key preserved
     assert top["correlation"] > 0.8


### PR DESCRIPTION
Shortens an over-long trailing comment so `black --check` passes; fixes the red CI on main after #12.